### PR TITLE
Change max_kernel (23) and allow sizes to 680

### DIFF
--- a/platforms/cuda/opts.gi
+++ b/platforms/cuda/opts.gi
@@ -102,10 +102,10 @@ ParseOptsCUDA := function(conf, t)
     
     # all dimensions need to be inthis array for the high perf MDDFT conf to kick in for now
     # size 320 is problematic at this point and needs attention. Need support for 3 stages to work first
-    MAX_KERNEL := 21;
+    MAX_KERNEL := 23;
     MAX_PRIME := 17;
     MIN_SIZE := 32;
-    MAX_SIZE := 320;
+    MAX_SIZE := 680;
 
     _thold := MAX_KERNEL;
     filter := (e) -> When(e[1] * e[2] <= _thold ^ 2, e[1] <= _thold and e[2] <= _thold, e[1] <= _thold and e[2] >= _thold);


### PR DESCRIPTION
Tweak parameters to generate HPC cuda versions of sizes required for exaFEL & WarpX
