### PR TITLE
Changes from Franz to enable more sizes for Free Space convolution

### DIFF
--- a/breakdown/tspl.gi
+++ b/breakdown/tspl.gi
@@ -7,6 +7,12 @@ NewRulesFor(TFCall, rec(
         forTransposition := false,
         children := nt -> [[ nt.params[1].withTags(nt.getTags()) ]],
         apply := (nt, c, cnt) -> c[1]
+    ),
+    TFCall_drop_tag2 := rec(
+        applicable := nt -> Length(nt.getTags()) = 3, 
+        forTransposition := false,
+        children := nt -> [[ TFCall(nt.params[1], nt.params[2]).withTags(nt.getTags(){[1,3]}) ]],
+        apply := (nt, c, cnt) -> c[1]
     )
 ));
 

--- a/examples/library-cuda/imdprdft-cuda.g
+++ b/examples/library-cuda/imdprdft-cuda.g
@@ -7,19 +7,27 @@
 Load(fftx);
 ImportAll(fftx);
 
-# startup script should set LocalConfig.fftx.defaultConf() -> LocalConfig.fftx.confGPU() 
-# conf := LocalConfig.fftx.defaultConf();  
 conf := LocalConfig.fftx.confGPU();
 
-d := 3;
-szcube := 4;
-name := "imdprdft"::StringInt(d)::"d";
+szcube := [ 32, 32, 32 ];
+name := "imdprdft";             ##  ::StringInt(d)::"d";
+sign := 1;
 
-PrintLine("imdprdft-cuda: d = ", d, " cube = ", szcube, "^3;\t\t##PICKME##");
+PrintLine("imdprdft-cuda: cube = ", szcube, ";\t\t##PICKME##");
 
-t := let(ns := Replicate(3, szcube),
-    TFCall(IMDPRDFT(ns, 1), 
-        rec(fname := name, params := []))
+szhalfcube := DropLast(szcube, 1)::[Int ( Last(szcube) / 2 ) + 1];
+var_1:= var("var_1", BoxND([0,0,0], TReal));
+var_2:= var("var_2", BoxND(szcube, TReal));
+var_3:= var("var_3", BoxND(szhalfcube, TReal));
+var_2:= X;
+var_3:= Y;
+
+t := TFCall(TDecl(TDAG([
+       TDAGNode ( TTensorI ( IMDPRDFT ( szcube, sign ), 1, APar, APar ), var_3, var_2 ),
+        ]),
+        [var_1]
+        ),
+    rec ( fname:=name, params:= [ ] )
 );
 
 opts := conf.getOpts(t);

--- a/examples/library-cuda/mdprdft-batch-cuda.g
+++ b/examples/library-cuda/mdprdft-batch-cuda.g
@@ -16,25 +16,38 @@ fwd := true;
 #fwd := false;
 
 nbatch := 2;
-d := 3;
-szcube := 64;
-ns :=  Replicate(d, szcube);
+szcube := [ 64, 64, 64 ];
 
 if fwd then
     prdft := MDPRDFT;
-    k := 1;
+    sign := -1;
+    name := "mdprdft_3d_batch";
 else
     prdft := IMDPRDFT;
-    k := -1;
+    sign := 1;
+    name := "imdprdft_3d_batch";
 fi;
 
+# t := let(batch := nbatch,
+#     apat := APar,
+#     k := -1,
+#     name := "dft"::StringInt(Length(ns))::"d_batch",  
+#     TFCall(TTensorI(prdft(ns, k), nbatch, apat, apat), 
+#         rec(fname := name, params := []))
+# );
 
-t := let(batch := nbatch,
-    apat := APar,
-    k := -1,
-    name := "dft"::StringInt(Length(ns))::"d_batch",  
-    TFCall(TTensorI(prdft(ns, k), nbatch, apat, apat), 
-        rec(fname := name, params := []))
+szhalfcube := DropLast ( szcube, 1 )::[ Int ( Last ( szcube ) / 2 ) + 1 ];
+var_1:= var("var_1", BoxND([0,0,0], TReal));
+var_2:= var("var_2", BoxND(szcube, TReal));
+var_3:= var("var_3", BoxND(szhalfcube, TReal));
+var_2:= X;
+var_3:= Y;
+t := TFCall ( TDecl ( TDAG ([
+                                TDAGNode ( TTensorI ( prdft ( szcube, sign ), nbatch, APar, APar ), var_3, var_2 ),
+                            ]),
+                      [var_1]
+                    ),
+              rec ( fname := name, params := [ ] )
 );
 
 opts := conf.getOpts(t);

--- a/platforms/cuda/opts.gi
+++ b/platforms/cuda/opts.gi
@@ -102,7 +102,7 @@ ParseOptsCUDA := function(conf, t)
     
     # all dimensions need to be inthis array for the high perf MDDFT conf to kick in for now
     # size 320 is problematic at this point and needs attention. Need support for 3 stages to work first
-    MAX_KERNEL := 25;
+    MAX_KERNEL := 26;
     MAX_PRIME := 17;
     MIN_SIZE := 32;
     MAX_SIZE := 680;


### PR DESCRIPTION
Changes from Franz to enable more sizes for Free Space Convolution
Changes to examples/library-cuda/imdprdft-cuda.g and examples/library-cuda/mdprdft-batch-cuda.g to get them to work.